### PR TITLE
Strip <fw> elements

### DIFF
--- a/ep2dracor.xsl
+++ b/ep2dracor.xsl
@@ -155,7 +155,7 @@
   </xsl:template>
 
   <xsl:template
-    match="tei:*[tei:w or tei:pc]"
+    match="tei:*[(tei:w or tei:pc) and local-name() ne ('fw')]"
   >
     <xsl:copy>
       <xsl:apply-templates select="@*|*"/>
@@ -269,9 +269,10 @@
 
   <!-- strip machine generated castlist -->
   <xsl:template match="tei:div[@type='machine-generated_castlist']" />
-
   <!-- strip textual notes -->
   <xsl:template match="tei:div[@type='textual_notes']" />
+  <!-- strip forme work (fw) -->
+  <xsl:template match="tei:fw" />
 
   <xsl:template name="titles">
     <xsl:variable name="ep-title" select="//tei:xenoData/ep:epHeader/ep:title[1]"/>

--- a/tei/anon-the-true-chronicle-of-king-leir.xml
+++ b/tei/anon-the-true-chronicle-of-king-leir.xml
@@ -506,8 +506,6 @@
               <speaker>Leir </speaker>
               <l>Deare Gonorill, kind Ragan, sweet Cordella </l>
               <pb xml:id="eng000100-005-b"/>
-              <fw>B <milestone n="B1r" unit="unspec"/>
-              </fw>
               <l>Ye florishing branches of a Kingly stocke, </l>
               <l>Sprung from a tree that once did flourish greene, </l>
               <l>Whose blossomes now are nipt with Winters frost, </l>
@@ -1032,8 +1030,6 @@
               <speaker>Cam. </speaker>
               <l>No other scuse of absence can I frame, </l>
               <pb xml:id="eng000100-009-b"/>
-              <fw>C <milestone n="C1r" unit="unspec"/>
-              </fw>
               <l>Then what my brother hath inform'd your Grace: </l>
               <l>For our vndeserued welcome, we do vowe, </l>
               <l>Perpetually to rest at your commaund. </l>
@@ -1569,8 +1565,6 @@
             </sp>
             <pb xml:id="eng000100-013-b"/>
             <sp who="#eng000100-goneril" xml:id="eng000100-e110780">
-              <fw>D <milestone n="D1r" unit="unspec"/>
-              </fw>
               <speaker>Gon. </speaker>
               <l>What, do you feare, that I haue angred him? </l>
               <l>Hath he complaynd of me vnto my Lord: </l>
@@ -2073,8 +2067,6 @@
               <l>Oh, what disaster chaunce hath bin the cause, </l>
               <l>To make your cheeks so hollow, spare and leane? </l>
               <pb xml:id="eng000100-017-b"/>
-              <fw>E <milestone n="E1r" unit="unspec"/>
-              </fw>
               <l>He cannot speake for weeping: for Gods loue, come. </l>
               <l>Let vs refresh him with some needfull things, </l>
               <l>And at more leysure we may better know, </l>
@@ -2649,9 +2641,6 @@
               <speaker>Leir. </speaker>
               <l>Hither my daughter meanes to come disguis'd </l>
               <pb xml:id="eng000100-021-b"/>
-              <fw>
-                <milestone n="F1r" unit="unspec"/>
-              </fw>
               <l>Ile sit me downe, and read vntill she come. </l>
             </sp>
             <stage xml:id="eng000100-e118740">Pull out a booke and sit downe. </stage>
@@ -2784,9 +2773,6 @@
               <l>How haue you any hope to be deliuered? </l>
               <l>This comes, because you haue no better stay, </l>
               <pb xml:id="eng000100-022-b"/>
-              <fw>
-                <milestone n="F2r" unit="unspec"/>
-              </fw>
               <l>But fall asleepe, when you should watch and pray: </l>
             </sp>
             <sp who="#eng000100-king" xml:id="eng000100-e119670">
@@ -2874,9 +2860,6 @@
               <l>Now for the safegard of my conscience, </l>
               <l>Do me the pleasure for to kill your selues: </l>
               <pb xml:id="eng000100-023-a"/>
-              <fw>
-                <milestone n="F2v" unit="unspec"/>
-              </fw>
               <l>So shall you saue me labour for to do it, </l>
               <l>And proue your selues true old men of your words. </l>
               <l>And here I vow in sight of all the world, </l>
@@ -2930,9 +2913,6 @@
               <speaker>Mes. </speaker>
               <l>As I am a perfit gentleman, thou speakst French to me: </l>
               <pb xml:id="eng000100-023-b"/>
-              <fw>
-                <milestone n="F3r" unit="unspec"/>
-              </fw>
               <l>I neuer heard Cordellaes name before, </l>
               <l>Nor neuer was in Fraunce in all my life: </l>
               <l>I neuer knew thou hadst a daughter there, </l>
@@ -3003,9 +2983,6 @@
               <l>I sweare by earth, the mother of vs all. </l>
             </sp>
             <pb xml:id="eng000100-024-a"/>
-            <fw>
-              <milestone n="F3v" unit="unspec"/>
-            </fw>
             <sp who="#eng000100-king" xml:id="eng000100-e121160">
               <speaker>Leir. </speaker>
               <l>Sweare not by earth; for she abhors to beare </l>
@@ -3068,9 +3045,6 @@
               <l>The latest kindnesse ile request of thee, </l>
               <l>Is that thou go vnto my daughter Cordella, </l>
               <pb xml:id="eng000100-024-b"/>
-              <fw>
-                <milestone n="F4r" unit="unspec"/>
-              </fw>
               <l>And carry her her fathers latest blessing: </l>
               <l>Withall desire her, that she will forgiue me; </l>
               <l>For I haue wrongd her without any cause. </l>
@@ -3135,9 +3109,6 @@
               <l>Yet for my sake, and as thou art a man, </l>
               <l>Spare this my friend, that hither with me came? </l>
               <pb xml:id="eng000100-025-a"/>
-              <fw>
-                <milestone n="F4v" unit="unspec"/>
-              </fw>
               <l>I brought him forth, whereas he had not bin, </l>
               <l>But for good will to beare me company. </l>
               <l>He left his friends, his country and his goods, </l>
@@ -3191,8 +3162,6 @@
               <l>Now when thou wilt come make an end of me. </l>
             </sp>
             <pb xml:id="eng000100-025-b"/>
-            <fw>G <milestone n="G1r" unit="unspec"/>
-            </fw>
             <stage xml:id="eng000100-e122540">He lets fall the other dagger. </stage>
             <sp who="#eng000100-perillus" xml:id="eng000100-e122550">
               <speaker>Per. </speaker>
@@ -3744,8 +3713,6 @@
               <speaker>Leir. </speaker>
               <l>Ah, kind Perillus, that is it I feare, </l>
               <pb xml:id="eng000100-029-b"/>
-              <fw>H <milestone n="H1r" unit="unspec"/>
-              </fw>
               <l>And makes me faynt, or euer I come there. </l>
               <l>Can kindnesse spring out of ingratitude? </l>
               <l>Or loue be reapt, where hatred hath bin sowne? </l>
@@ -4294,8 +4261,6 @@
               <l>I feele a hell of conscience in my brest, </l>
               <l>Tormenting me with horrour for my fact, </l>
               <pb xml:id="eng000100-033-b"/>
-              <fw>I <milestone n="I1r" unit="unspec"/>
-              </fw>
               <l>And makes me in an agony of doubt, </l>
               <l>For feare the world should find my dealing out. </l>
               <l>The slaue whom I appoynted for the act, </l>

--- a/tei/marlowe-tamburlaine-1.xml
+++ b/tei/marlowe-tamburlaine-1.xml
@@ -3881,9 +3881,6 @@
                   <l>And ad more strength to your dominions </l>
                   <l>Then euer yet confirm'd th'Egyptian Crown. </l>
                   <pb xml:id="eng000125-041-b"/>
-                  <fw>
-                    <milestone n="F1r" unit="unspec"/>
-                  </fw>
                   <l>The God of war resignes his roume to me, </l>
                   <l>Meaning to make me Generall of the world, </l>
                   <l>Ioue viewing me in armes, lookes pale and wan, </l>
@@ -3919,9 +3916,6 @@
                   <l>Mighty hath God &amp; Mahomet made thy hand </l>
                   <l>(Renowmed tamburlain) to whom all kings </l>
                   <pb xml:id="eng000125-042-a"/>
-                  <fw>
-                    <milestone n="F1v" unit="unspec"/>
-                  </fw>
                   <l>Of force must yeeld their crownes and Emperies, </l>
                   <l>And I am pleasde with this my ouerthrow: </l>
                   <l>If as beseemes a person of thy state, </l>
@@ -3979,9 +3973,6 @@
                   <l>That darted mount aimes at her brother Ioue: </l>
                   <l>So lookes my Loue, shadowing in her browes </l>
                   <pb xml:id="eng000125-042-b"/>
-                  <fw>
-                    <milestone n="F2r" unit="unspec"/>
-                  </fw>
                   <l>Triumphes and Trophees for my victories: </l>
                   <l>Or as Latonas daughter bent to armes, </l>
                   <l>Adding more courage to my conquering mind, </l>
@@ -4016,9 +4007,6 @@
         <body>
           <div type="illustration" xml:id="eng000125-e127760">
             <pb xml:id="eng000125-043-a"/>
-            <fw>
-              <milestone n="F2v" unit="unspec"/>
-            </fw>
             <p>
               <figure>
                 <head>Tamburlaine, the great. </head>
@@ -4028,9 +4016,6 @@
           </div>
           <div n="2" type="part" xml:id="eng000125-e127820">
             <pb xml:id="eng000125-043-b"/>
-            <fw>
-              <milestone n="F3r" unit="unspec"/>
-            </fw>
             <head>THE SECOND PART OF The bloody Conquests of mighty Tamburlaine. With his impassionate fury, for the death of his Lady and loue, faire Zenocrate: his fourme of exhortation and discipline to his three sons, and the maner of his own death. </head>
             <div type="prologue" xml:id="eng000125-e127850">
               <head>The Prologue. </head>
@@ -4058,9 +4043,6 @@
                   <l>Which kept his father in an yron cage: </l>
                   <l>Now haue we martcht from faire Natolia </l>
                   <pb xml:id="eng000125-044-a"/>
-                  <fw>
-                    <milestone n="F3v" unit="unspec"/>
-                  </fw>
                   <l>Two hundred leagues, and on Danubius banks, </l>
                   <l>Our warlike hoste in compleat armour rest, </l>
                   <l>Where Sigismond the king of Hungary </l>
@@ -4099,9 +4081,6 @@
                   <l>The slaughtered bodies of these Christians. </l>
                   <l>The Terrene main wherin Danubius fals, </l>
                   <pb xml:id="eng000125-044-b"/>
-                  <fw>
-                    <milestone n="F4r" unit="unspec"/>
-                  </fw>
                   <l>Shall by this battell be the bloody Sea. </l>
                   <l>The wandring Sailers of proud Italy, </l>
                   <l>Shall meet those Christians fleeting with the tyde, </l>
@@ -4141,9 +4120,6 @@
                   <l>From Scythia to the Orientall Plage </l>
                   <l>Of India, wher raging Lantchidol </l>
                   <pb xml:id="eng000125-045-a"/>
-                  <fw>
-                    <milestone n="F4v" unit="unspec"/>
-                  </fw>
                   <l>Beates on the regions with his boysterous blowes, </l>
                   <l>That neuer sea-man yet discouered: </l>
                   <l>All Asia is in Armes with tamburlaine, </l>
@@ -4181,9 +4157,6 @@
                   <l>That thou thy self, then County-Pallatine, </l>
                   <l>The king of Boheme, and the Austrich Duke, </l>
                   <pb xml:id="eng000125-045-b"/>
-                  <fw>
-                    <milestone n="F5r" unit="unspec"/>
-                  </fw>
                   <l>Sent Herralds out, which basely on their knees </l>
                   <l>In all your names desirde a truce of me? </l>
                   <l>Forgetst thou, that to haue me raise my siege, </l>
@@ -4232,9 +4205,6 @@
                   <speaker>Sig. </speaker>
                   <l>Then here I sheath it, and giue thee my hand, </l>
                   <pb xml:id="eng000125-046-a"/>
-                  <fw>
-                    <milestone n="F5v" unit="unspec"/>
-                  </fw>
                   <l>Neuer to draw it out, or manage armes </l>
                   <l>Against thy selfe or thy confederates: </l>
                   <l>But whilst I liue will be at truce with thee. </l>
@@ -4282,9 +4252,6 @@
                   <l>I thank thee Sigismond, but when I war, </l>
                   <l>All Asia Minor, Affrica, and Greece </l>
                   <pb xml:id="eng000125-046-b"/>
-                  <fw>
-                    <milestone n="F6r" unit="unspec"/>
-                  </fw>
                   <l>Follow my Standard and my thundring Drums: </l>
                   <l>Come let vs goe and banquet in our tents: </l>
                   <l>I will dispatch chiefe of my army hence </l>
@@ -4355,9 +4322,6 @@
                   <speaker>Cal. </speaker>
                   <l>By Cario runs to Alexandria Bay, </l>
                   <pb xml:id="eng000125-047-a"/>
-                  <fw>
-                    <milestone n="F6v" unit="unspec"/>
-                  </fw>
                   <l>Darotes streames, wherin at anchor lies </l>
                   <l>A Turkish Gally of my royall fleet, </l>
                   <l>Waiting my comming to the riuer side, </l>
@@ -4391,9 +4355,6 @@
                   <l>As that faire vail that couers all the world: </l>
                   <l>When Phoebus leaning from his Hemi-Spheare, </l>
                   <pb xml:id="eng000125-047-b"/>
-                  <fw>
-                    <milestone n="F7r" unit="unspec"/>
-                  </fw>
                   <l>Discendeth downward to th'Antipodes. </l>
                   <l>And more than this, for all I cannot tell. </l>
                 </sp>
@@ -4455,9 +4416,6 @@
               </div>
               <div n="4 (?recte 3)" type="scene" xml:id="eng000125-e131000">
                 <pb xml:id="eng000125-048-a"/>
-                <fw>
-                  <milestone n="F7v" unit="unspec"/>
-                </fw>
                 <head>Actus. 1. Scaena. 4. </head>
                 <stage xml:id="eng000125-e131030">Tamburlaine with zenocrate, and his three sonnes, Calyphas, Amyras, and Celebinus, with drummes and trumpets. </stage>
                 <sp who="#eng000125-tamburlaine" xml:id="eng000125-e131040">
@@ -4495,9 +4453,6 @@
                   <l>Their haire as white as milke and soft as Downe. </l>
                   <l>Which should be like the quilles of Porcupines. </l>
                   <pb xml:id="eng000125-048-b"/>
-                  <fw>
-                    <milestone n="F8r" unit="unspec"/>
-                  </fw>
                   <l>As blacke as Ieat, and hard as Iron or steel, </l>
                   <l>Bewraies they are too dainty for the wars. </l>
                   <l>Their fingers made to quauer on a Lute, </l>
@@ -4544,9 +4499,6 @@
                   <l>These words assure me boy, thou art my sonne, </l>
                   <l>When I am old and cannot mannage armes, </l>
                   <pb xml:id="eng000125-049-a"/>
-                  <fw>
-                    <milestone n="F8v" unit="unspec"/>
-                  </fw>
                   <l>Be thou the scourge and terrour of the world, </l>
                 </sp>
                 <sp who="#eng000125-amyras" xml:id="eng000125-e131750">


### PR DESCRIPTION
This modifies the XSLT to strip `fw` elements from the sources which are not supported by the DraCor schema.