### PR TITLE
Simplify licence markup

### DIFF
--- a/ep2dracor.xsl
+++ b/ep2dracor.xsl
@@ -352,7 +352,7 @@
       <publisher xml:id="dracor">DraCor</publisher>
       <idno type="URL">https://dracor.org/</idno>
       <availability>
-        <licence target="https://creativecommons.org/publicdomain/zero/1.0">CC0 1.0</licence>
+        <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
       </availability>
       <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"></idno>
     </publicationStmt>

--- a/ep2dracor.xsl
+++ b/ep2dracor.xsl
@@ -352,10 +352,7 @@
       <publisher xml:id="dracor">DraCor</publisher>
       <idno type="URL">https://dracor.org/</idno>
       <availability>
-        <licence>
-          <ab>CC0 1.0</ab>
-          <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-        </licence>
+        <licence target="https://creativecommons.org/publicdomain/zero/1.0">CC0 1.0</licence>
       </availability>
       <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"></idno>
     </publicationStmt>

--- a/tei/a-the-valiant-welshman.xml
+++ b/tei/a-the-valiant-welshman.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/alexander-caesar.xml
+++ b/tei/alexander-caesar.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/alexander-croesus.xml
+++ b/tei/alexander-croesus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/alexander-darius.xml
+++ b/tei/alexander-darius.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/alexander-the-alexandraean-tragedy.xml
+++ b/tei/alexander-the-alexandraean-tragedy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-a-knack-to-know-a-knave.xml
+++ b/tei/anon-a-knack-to-know-a-knave.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-a-larum-for-london.xml
+++ b/tei/anon-a-larum-for-london.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-alphonsus-emperor-of-germany.xml
+++ b/tei/anon-alphonsus-emperor-of-germany.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-arden-of-faversham.xml
+++ b/tei/anon-arden-of-faversham.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-band-cuff-and-ruff.xml
+++ b/tei/anon-band-cuff-and-ruff.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-bonduca.xml
+++ b/tei/anon-bonduca.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-brutus-of-alba.xml
+++ b/tei/anon-brutus-of-alba.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-caesar-and-pompey.xml
+++ b/tei/anon-caesar-and-pompey.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-canterbury-his-change-of-diet.xml
+++ b/tei/anon-canterbury-his-change-of-diet.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-emilia.xml
+++ b/tei/anon-emilia.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-fair-em.xml
+++ b/tei/anon-fair-em.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-henry-ii-king-of-england.xml
+++ b/tei/anon-henry-ii-king-of-england.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-jack-straw.xml
+++ b/tei/anon-jack-straw.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-jeronimo-with-the-wars-of-portugal-1.xml
+++ b/tei/anon-jeronimo-with-the-wars-of-portugal-1.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-knavery-in-all-trades.xml
+++ b/tei/anon-knavery-in-all-trades.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-locrine.xml
+++ b/tei/anon-locrine.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-mucedorus-and-amadine.xml
+++ b/tei/anon-mucedorus-and-amadine.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-nero.xml
+++ b/tei/anon-nero.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-nobody-and-somebody.xml
+++ b/tei/anon-nobody-and-somebody.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-piso-s-conspiracy.xml
+++ b/tei/anon-piso-s-conspiracy.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-produced-by-duffett-the-amorous-old-woman.xml
+++ b/tei/anon-produced-by-duffett-the-amorous-old-woman.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-produced-by-horden-neglected-virtue.xml
+++ b/tei/anon-produced-by-horden-neglected-virtue.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-romulus-and-hersilia.xml
+++ b/tei/anon-romulus-and-hersilia.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-settle-the-fairy-queen.xml
+++ b/tei/anon-settle-the-fairy-queen.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-she-ventures-and-he-wins.xml
+++ b/tei/anon-she-ventures-and-he-wins.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-bloody-duke.xml
+++ b/tei/anon-the-bloody-duke.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-contention-between-liberality-and-prodigality.xml
+++ b/tei/anon-the-contention-between-liberality-and-prodigality.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-cornish-comedy.xml
+++ b/tei/anon-the-cornish-comedy.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-counterfeit-bridegroom.xml
+++ b/tei/anon-the-counterfeit-bridegroom.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-counterfeits.xml
+++ b/tei/anon-the-counterfeits.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-feigned-astrologer.xml
+++ b/tei/anon-the-feigned-astrologer.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-island-princess.xml
+++ b/tei/anon-the-island-princess.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-london-prodigal.xml
+++ b/tei/anon-the-london-prodigal.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-maid-s-metamorphosis.xml
+++ b/tei/anon-the-maid-s-metamorphosis.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-merry-devil-of-edmonton.xml
+++ b/tei/anon-the-merry-devil-of-edmonton.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-mistaken-husband.xml
+++ b/tei/anon-the-mistaken-husband.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-pedlar-s-prophecy.xml
+++ b/tei/anon-the-pedlar-s-prophecy.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-reign-of-king-edward-the-third.xml
+++ b/tei/anon-the-reign-of-king-edward-the-third.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-siege-and-surrender-of-mons.xml
+++ b/tei/anon-the-siege-and-surrender-of-mons.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-taming-of-a-shrew.xml
+++ b/tei/anon-the-taming-of-a-shrew.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-trial-of-chivalry.xml
+++ b/tei/anon-the-trial-of-chivalry.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-true-chronicle-of-king-leir.xml
+++ b/tei/anon-the-true-chronicle-of-king-leir.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-true-tragedy-of-richard-the-third.xml
+++ b/tei/anon-the-true-tragedy-of-richard-the-third.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-unnatural-mother.xml
+++ b/tei/anon-the-unnatural-mother.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-wars-of-cyrus.xml
+++ b/tei/anon-the-wars-of-cyrus.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-the-woman-turned-bully.xml
+++ b/tei/anon-the-woman-turned-bully.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-valentinian.xml
+++ b/tei/anon-valentinian.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-wily-beguiled.xml
+++ b/tei/anon-wily-beguiled.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-wine-beer-and-ale-together-by-the-ears.xml
+++ b/tei/anon-wine-beer-and-ale-together-by-the-ears.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-wit-for-money.xml
+++ b/tei/anon-wit-for-money.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/anon-wits-led-by-the-nose.xml
+++ b/tei/anon-wits-led-by-the-nose.xml
@@ -12,10 +12,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ariosto-supposes.xml
+++ b/tei/ariosto-supposes.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/armin-the-two-maids-of-more-clacke.xml
+++ b/tei/armin-the-two-maids-of-more-clacke.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/arrowsmith-the-reformation.xml
+++ b/tei/arrowsmith-the-reformation.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/bailey-the-spiteful-sister.xml
+++ b/tei/bailey-the-spiteful-sister.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/bancroft-sentorius.xml
+++ b/tei/bancroft-sentorius.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/banks-cyrus-the-great.xml
+++ b/tei/banks-cyrus-the-great.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/banks-the-destruction-of-troy.xml
+++ b/tei/banks-the-destruction-of-troy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/banks-the-innocent-usurper.xml
+++ b/tei/banks-the-innocent-usurper.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/banks-the-island-queens.xml
+++ b/tei/banks-the-island-queens.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/banks-the-rival-kings.xml
+++ b/tei/banks-the-rival-kings.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/banks-the-unhappy-favourite.xml
+++ b/tei/banks-the-unhappy-favourite.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/barnes-the-devil-s-charter.xml
+++ b/tei/barnes-the-devil-s-charter.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/baron-mirza.xml
+++ b/tei/baron-mirza.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/barry-ram-alley.xml
+++ b/tei/barry-ram-alley.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-a-king-and-no-king.xml
+++ b/tei/beaumont-fletcher-a-king-and-no-king.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-cupid-s-revenge.xml
+++ b/tei/beaumont-fletcher-cupid-s-revenge.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-love-s-pilgrimage.xml
+++ b/tei/beaumont-fletcher-love-s-pilgrimage.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-massinger-beggars-bush.xml
+++ b/tei/beaumont-fletcher-massinger-beggars-bush.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-massinger-love-s-cure.xml
+++ b/tei/beaumont-fletcher-massinger-love-s-cure.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-massinger-thierry-and-theodoret.xml
+++ b/tei/beaumont-fletcher-massinger-thierry-and-theodoret.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-philaster.xml
+++ b/tei/beaumont-fletcher-philaster.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-the-coxcomb.xml
+++ b/tei/beaumont-fletcher-the-coxcomb.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-the-maid-s-tragedy.xml
+++ b/tei/beaumont-fletcher-the-maid-s-tragedy.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-the-scornful-lady.xml
+++ b/tei/beaumont-fletcher-the-scornful-lady.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-fletcher-the-woman-hater.xml
+++ b/tei/beaumont-fletcher-the-woman-hater.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-the-knight-of-the-burning-pestle.xml
+++ b/tei/beaumont-the-knight-of-the-burning-pestle.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/beaumont-the-masque-of-the-inner-temple-and-gray-s-inn.xml
+++ b/tei/beaumont-the-masque-of-the-inner-temple-and-gray-s-inn.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/bedloe-the-excommunicated-prince.xml
+++ b/tei/bedloe-the-excommunicated-prince.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-abdelazer.xml
+++ b/tei/behn-abdelazer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-amorous-prince.xml
+++ b/tei/behn-the-amorous-prince.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-city-heiress.xml
+++ b/tei/behn-the-city-heiress.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-debauchee.xml
+++ b/tei/behn-the-debauchee.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-dutch-lover.xml
+++ b/tei/behn-the-dutch-lover.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-emperor-of-the-moon.xml
+++ b/tei/behn-the-emperor-of-the-moon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-false-count.xml
+++ b/tei/behn-the-false-count.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-feign-d-curtizans.xml
+++ b/tei/behn-the-feign-d-curtizans.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-forced-marriage.xml
+++ b/tei/behn-the-forced-marriage.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-lucky-chance.xml
+++ b/tei/behn-the-lucky-chance.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-revenge.xml
+++ b/tei/behn-the-revenge.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-roundheads.xml
+++ b/tei/behn-the-roundheads.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-rover-1.xml
+++ b/tei/behn-the-rover-1.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/behn-the-widow-ranter.xml
+++ b/tei/behn-the-widow-ranter.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/belchier-hans-beer-pot.xml
+++ b/tei/belchier-hans-beer-pot.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/belon-the-mock-duellist.xml
+++ b/tei/belon-the-mock-duellist.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/berkeley-the-lost-lady.xml
+++ b/tei/berkeley-the-lost-lady.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/betterton-the-prophetess.xml
+++ b/tei/betterton-the-prophetess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/boothby-marcelia.xml
+++ b/tei/boothby-marcelia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/bourne-the-contended-cuckold.xml
+++ b/tei/bourne-the-contended-cuckold.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/bower-appius-and-virginia.xml
+++ b/tei/bower-appius-and-virginia.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/boyer-achilles.xml
+++ b/tei/boyer-achilles.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/boyle-guzman.xml
+++ b/tei/boyle-guzman.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/boyle-henry-v.xml
+++ b/tei/boyle-henry-v.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/boyle-herod-the-great.xml
+++ b/tei/boyle-herod-the-great.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/boyle-mr-anthony.xml
+++ b/tei/boyle-mr-anthony.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/boyle-mustapha-son-of-solyman-the-magnificent.xml
+++ b/tei/boyle-mustapha-son-of-solyman-the-magnificent.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brady-the-rape.xml
+++ b/tei/brady-the-rape.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brathwait-mercurius-britannicus.xml
+++ b/tei/brathwait-mercurius-britannicus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-a-jovial-crew.xml
+++ b/tei/brome-a-jovial-crew.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-a-mad-couple-well-matched.xml
+++ b/tei/brome-a-mad-couple-well-matched.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-antipodes.xml
+++ b/tei/brome-the-antipodes.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-city-wit.xml
+++ b/tei/brome-the-city-wit.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-court-beggar.xml
+++ b/tei/brome-the-court-beggar.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-cunning-lovers.xml
+++ b/tei/brome-the-cunning-lovers.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-damoiselle-or-the-new-ordinary.xml
+++ b/tei/brome-the-damoiselle-or-the-new-ordinary.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-english-moor.xml
+++ b/tei/brome-the-english-moor.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-lovesick-court.xml
+++ b/tei/brome-the-lovesick-court.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-new-academy.xml
+++ b/tei/brome-the-new-academy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-northern-lass.xml
+++ b/tei/brome-the-northern-lass.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-novella.xml
+++ b/tei/brome-the-novella.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-queen-and-concubine.xml
+++ b/tei/brome-the-queen-and-concubine.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-queen-s-exchange.xml
+++ b/tei/brome-the-queen-s-exchange.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-sparagus-garden.xml
+++ b/tei/brome-the-sparagus-garden.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/brome-the-weeding-of-the-covent-garden.xml
+++ b/tei/brome-the-weeding-of-the-covent-garden.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/browne-physic-lies-a-bleeding.xml
+++ b/tei/browne-physic-lies-a-bleeding.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/burnaby-the-reformed-wife.xml
+++ b/tei/burnaby-the-reformed-wife.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/burnell-landgartha.xml
+++ b/tei/burnell-landgartha.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/campion-the-masque-at-lord-hay-s-marriage.xml
+++ b/tei/campion-the-masque-at-lord-hay-s-marriage.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/carew-coelum-britannicum.xml
+++ b/tei/carew-coelum-britannicum.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/carlell-the-deserving-favorite.xml
+++ b/tei/carlell-the-deserving-favorite.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/carlisle-the-fortune-hunters.xml
+++ b/tei/carlisle-the-fortune-hunters.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/carpenter-the-pragmatical-jesuit-new-leavened.xml
+++ b/tei/carpenter-the-pragmatical-jesuit-new-leavened.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/carr-pluto-furens-et-vinctus.xml
+++ b/tei/carr-pluto-furens-et-vinctus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cartwright-the-heroic-lover.xml
+++ b/tei/cartwright-the-heroic-lover.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cartwright-the-royal-slave.xml
+++ b/tei/cartwright-the-royal-slave.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cary-mariam-the-fair-queen-of-jewry.xml
+++ b/tei/cary-mariam-the-fair-queen-of-jewry.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cary-the-marriage-night.xml
+++ b/tei/cary-the-marriage-night.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/caryl-sir-salomon.xml
+++ b/tei/caryl-sir-salomon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/caryl-the-english-princess.xml
+++ b/tei/caryl-the-english-princess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cavendish-shirley-the-country-captain.xml
+++ b/tei/cavendish-shirley-the-country-captain.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cavendish-the-triumphant-widow.xml
+++ b/tei/cavendish-the-triumphant-widow.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cavendish-the-variety.xml
+++ b/tei/cavendish-the-variety.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/centlivre-the-perjured-husband.xml
+++ b/tei/centlivre-the-perjured-husband.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chamberlain-the-swaggering-damsel.xml
+++ b/tei/chamberlain-the-swaggering-damsel.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-all-fools.xml
+++ b/tei/chapman-all-fools.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-an-humorous-day-s-mirth.xml
+++ b/tei/chapman-an-humorous-day-s-mirth.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-bussy-d-ambois.xml
+++ b/tei/chapman-bussy-d-ambois.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-caesar-and-pompey-the-wars-of-caesar-and-pompey.xml
+++ b/tei/chapman-caesar-and-pompey-the-wars-of-caesar-and-pompey.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-jonson-marston-eastward-ho.xml
+++ b/tei/chapman-jonson-marston-eastward-ho.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-may-day.xml
+++ b/tei/chapman-may-day.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-monsieur-d-olive.xml
+++ b/tei/chapman-monsieur-d-olive.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-sir-giles-goosecap.xml
+++ b/tei/chapman-sir-giles-goosecap.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-the-blind-beggar-of-alexandria.xml
+++ b/tei/chapman-the-blind-beggar-of-alexandria.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-the-conspiracy-of-charles-duke-of-byron.xml
+++ b/tei/chapman-the-conspiracy-of-charles-duke-of-byron.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-the-gentleman-usher.xml
+++ b/tei/chapman-the-gentleman-usher.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-the-masque-of-the-middle-temple-and-lincoln-s-inn.xml
+++ b/tei/chapman-the-masque-of-the-middle-temple-and-lincoln-s-inn.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-the-revenge-of-bussy-d-ambois.xml
+++ b/tei/chapman-the-revenge-of-bussy-d-ambois.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-the-tragedy-of-charles-duke-of-byron.xml
+++ b/tei/chapman-the-tragedy-of-charles-duke-of-byron.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-the-widow-s-tears.xml
+++ b/tei/chapman-the-widow-s-tears.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chapman-two-wise-men-and-all-the-rest-fools.xml
+++ b/tei/chapman-two-wise-men-and-all-the-rest-fools.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/chettle-hoffman.xml
+++ b/tei/chettle-hoffman.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cibber-xerxes.xml
+++ b/tei/cibber-xerxes.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/clerke-marciano.xml
+++ b/tei/clerke-marciano.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/congreve-the-double-dealer.xml
+++ b/tei/congreve-the-double-dealer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/congreve-the-mourning-bride.xml
+++ b/tei/congreve-the-mourning-bride.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/congreve-the-way-of-the-world.xml
+++ b/tei/congreve-the-way-of-the-world.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cooke-greene-s-tu-quoque.xml
+++ b/tei/cooke-greene-s-tu-quoque.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/corneille-amorous-orontus.xml
+++ b/tei/corneille-amorous-orontus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/corneille-nicomede.xml
+++ b/tei/corneille-nicomede.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/corneille-pompey-the-great.xml
+++ b/tei/corneille-pompey-the-great.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/corneille-pompey.xml
+++ b/tei/corneille-pompey.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/corneille-the-cid-1.xml
+++ b/tei/corneille-the-cid-1.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/corye-the-generous-enemies.xml
+++ b/tei/corye-the-generous-enemies.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cowley-cutter-of-coleman-street.xml
+++ b/tei/cowley-cutter-of-coleman-street.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cowley-love-s-riddle.xml
+++ b/tei/cowley-love-s-riddle.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/crauford-courtship-a-la-mode.xml
+++ b/tei/crauford-courtship-a-la-mode.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/crowne-charles-viii-of-france.xml
+++ b/tei/crowne-charles-viii-of-france.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/crowne-darius-king-of-persia.xml
+++ b/tei/crowne-darius-king-of-persia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/crowne-juliana.xml
+++ b/tei/crowne-juliana.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/crowne-sir-courtly-nice.xml
+++ b/tei/crowne-sir-courtly-nice.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/crowne-the-destruction-of-jerusalem.xml
+++ b/tei/crowne-the-destruction-of-jerusalem.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/crowne-the-misery-of-civil-war.xml
+++ b/tei/crowne-the-misery-of-civil-war.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/crowne-thyestes.xml
+++ b/tei/crowne-thyestes.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/cumber-the-two-merry-milkmaids.xml
+++ b/tei/cumber-the-two-merry-milkmaids.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-the-knave-in-grain-new-vamped.xml
+++ b/tei/d-the-knave-in-grain-new-vamped.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-a-commonwealth-of-women.xml
+++ b/tei/d-urfey-a-commonwealth-of-women.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-a-fond-husband.xml
+++ b/tei/d-urfey-a-fond-husband.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-a-fool-s-preferment.xml
+++ b/tei/d-urfey-a-fool-s-preferment.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-cinthia-and-endimion.xml
+++ b/tei/d-urfey-cinthia-and-endimion.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-love-for-money.xml
+++ b/tei/d-urfey-love-for-money.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-massaniello-1-2.xml
+++ b/tei/d-urfey-massaniello-1-2.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-squire-oldsapp.xml
+++ b/tei/d-urfey-squire-oldsapp.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-the-comical-history-of-don-quixote-2.xml
+++ b/tei/d-urfey-the-comical-history-of-don-quixote-2.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-the-fool-turned-critic.xml
+++ b/tei/d-urfey-the-fool-turned-critic.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-the-injured-princess.xml
+++ b/tei/d-urfey-the-injured-princess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-the-intrigues-at-versailles.xml
+++ b/tei/d-urfey-the-intrigues-at-versailles.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-the-marriage-hater-matched.xml
+++ b/tei/d-urfey-the-marriage-hater-matched.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-the-richmond-heiress.xml
+++ b/tei/d-urfey-the-richmond-heiress.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-the-royalist.xml
+++ b/tei/d-urfey-the-royalist.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/d-urfey-trick-for-trick.xml
+++ b/tei/d-urfey-trick-for-trick.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/daborne-a-christian-turned-turk.xml
+++ b/tei/daborne-a-christian-turned-turk.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dancer-agrippa-king-of-alba.xml
+++ b/tei/dancer-agrippa-king-of-alba.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/daniel-certaine-small-poems-lately-printed-with-the-tragedie-of-philotas.xml
+++ b/tei/daniel-certaine-small-poems-lately-printed-with-the-tragedie-of-philotas.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/daniel-cleopatra.xml
+++ b/tei/daniel-cleopatra.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/daniel-delia.xml
+++ b/tei/daniel-delia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/daniel-hymen-s-triumph.xml
+++ b/tei/daniel-hymen-s-triumph.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/daniel-philotas.xml
+++ b/tei/daniel-philotas.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/daniel-the-queen-s-arcadia.xml
+++ b/tei/daniel-the-queen-s-arcadia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/daniel-the-vision-of-the-twelve-goddesses.xml
+++ b/tei/daniel-the-vision-of-the-twelve-goddesses.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-albovine-king-of-the-lombards.xml
+++ b/tei/davenant-albovine-king-of-the-lombards.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-britannia-triumphans.xml
+++ b/tei/davenant-britannia-triumphans.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-circe.xml
+++ b/tei/davenant-circe.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-macbeth.xml
+++ b/tei/davenant-macbeth.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-salmacida-spolia.xml
+++ b/tei/davenant-salmacida-spolia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-the-cruel-brother.xml
+++ b/tei/davenant-the-cruel-brother.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-the-just-italian.xml
+++ b/tei/davenant-the-just-italian.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-the-siege-of-rhodes-1-2.xml
+++ b/tei/davenant-the-siege-of-rhodes-1-2.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-the-tempest.xml
+++ b/tei/davenant-the-tempest.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-the-temple-of-love.xml
+++ b/tei/davenant-the-temple-of-love.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenant-the-wits.xml
+++ b/tei/davenant-the-wits.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/davenport-a-new-trick-to-cheat-the-devil.xml
+++ b/tei/davenport-a-new-trick-to-cheat-the-devil.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/day-humor-out-of-breath.xml
+++ b/tei/day-humor-out-of-breath.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/day-law-tricks.xml
+++ b/tei/day-law-tricks.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/day-the-isle-of-gulls.xml
+++ b/tei/day-the-isle-of-gulls.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/day-the-parliament-of-bees.xml
+++ b/tei/day-the-parliament-of-bees.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/day-wilkins-rowley-the-travels-of-the-three-english-brothers.xml
+++ b/tei/day-wilkins-rowley-the-travels-of-the-three-english-brothers.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-blurt-master-constable.xml
+++ b/tei/dekker-blurt-master-constable.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-chettle-haughton-patient-grissel.xml
+++ b/tei/dekker-chettle-haughton-patient-grissel.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-ford-middleton-rowley-the-spanish-gypsy.xml
+++ b/tei/dekker-ford-middleton-rowley-the-spanish-gypsy.xml
@@ -36,10 +36,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-ford-the-sun-s-darling.xml
+++ b/tei/dekker-ford-the-sun-s-darling.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-haughton-day-lust-s-dominion.xml
+++ b/tei/dekker-haughton-day-lust-s-dominion.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-if-it-be-not-good-the-devil-is-in-it.xml
+++ b/tei/dekker-if-it-be-not-good-the-devil-is-in-it.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-massinger-the-virgin-martyr.xml
+++ b/tei/dekker-massinger-the-virgin-martyr.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-match-me-in-london.xml
+++ b/tei/dekker-match-me-in-london.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-middleton-the-bloody-banquet.xml
+++ b/tei/dekker-middleton-the-bloody-banquet.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-middleton-the-honest-whore-1.xml
+++ b/tei/dekker-middleton-the-honest-whore-1.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-middleton-the-roaring-girl.xml
+++ b/tei/dekker-middleton-the-roaring-girl.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-old-fortunatus.xml
+++ b/tei/dekker-old-fortunatus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-rowley-ford-the-witch-of-edmonton.xml
+++ b/tei/dekker-rowley-ford-the-witch-of-edmonton.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-satiromastix.xml
+++ b/tei/dekker-satiromastix.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-the-honest-whore-2.xml
+++ b/tei/dekker-the-honest-whore-2.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-the-noble-spanish-soldier.xml
+++ b/tei/dekker-the-noble-spanish-soldier.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-the-shoemaker-s-holiday.xml
+++ b/tei/dekker-the-shoemaker-s-holiday.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-the-whore-of-babylon.xml
+++ b/tei/dekker-the-whore-of-babylon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-the-wonder-of-a-kingdom.xml
+++ b/tei/dekker-the-wonder-of-a-kingdom.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-webster-northward-ho.xml
+++ b/tei/dekker-webster-northward-ho.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-webster-the-famous-history-of-sir-thomas-wyatt.xml
+++ b/tei/dekker-webster-the-famous-history-of-sir-thomas-wyatt.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dekker-webster-westward-ho.xml
+++ b/tei/dekker-webster-westward-ho.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/denham-the-sophy.xml
+++ b/tei/denham-the-sophy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dennis-iphigenia.xml
+++ b/tei/dennis-iphigenia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dennis-rinaldo-and-armida.xml
+++ b/tei/dennis-rinaldo-and-armida.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/desfontaines-the-cid-2.xml
+++ b/tei/desfontaines-the-cid-2.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/digby-elvira.xml
+++ b/tei/digby-elvira.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dilke-the-lover-s-luck.xml
+++ b/tei/dilke-the-lover-s-luck.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/doggett-the-country-wake.xml
+++ b/tei/doggett-the-country-wake.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dolce-jocasta.xml
+++ b/tei/dolce-jocasta.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/drake-the-sham-lawyer.xml
+++ b/tei/drake-the-sham-lawyer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/drue-the-duchess-of-suffolk.xml
+++ b/tei/drue-the-duchess-of-suffolk.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-albion-albanius.xml
+++ b/tei/dryden-albion-albanius.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-amboyna.xml
+++ b/tei/dryden-amboyna.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-amphitryon.xml
+++ b/tei/dryden-amphitryon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-an-evening-s-love.xml
+++ b/tei/dryden-an-evening-s-love.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-aureng-zebe.xml
+++ b/tei/dryden-aureng-zebe.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-cleomenes-the-spartan-hero.xml
+++ b/tei/dryden-cleomenes-the-spartan-hero.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-love-triumphant.xml
+++ b/tei/dryden-love-triumphant.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-marriage-a-la-mode.xml
+++ b/tei/dryden-marriage-a-la-mode.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-oedipus.xml
+++ b/tei/dryden-oedipus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-sir-martin-mar-all.xml
+++ b/tei/dryden-sir-martin-mar-all.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-the-assignation.xml
+++ b/tei/dryden-the-assignation.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-the-husband-his-own-cuckold.xml
+++ b/tei/dryden-the-husband-his-own-cuckold.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-the-spanish-friar.xml
+++ b/tei/dryden-the-spanish-friar.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-the-state-of-innocence-and-fall-of-man.xml
+++ b/tei/dryden-the-state-of-innocence-and-fall-of-man.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-troilus-and-cressida.xml
+++ b/tei/dryden-troilus-and-cressida.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/dryden-tyrannic-love.xml
+++ b/tei/dryden-tyrannic-love.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/duffett-psyche-debauched.xml
+++ b/tei/duffett-psyche-debauched.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/duffett-the-empress-of-morocco.xml
+++ b/tei/duffett-the-empress-of-morocco.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/duffett-the-mock-tempest.xml
+++ b/tei/duffett-the-mock-tempest.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ecclestone-noah-s-flood.xml
+++ b/tei/ecclestone-noah-s-flood.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/etherege-the-comical-revenge.xml
+++ b/tei/etherege-the-comical-revenge.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fane-love-in-the-dark.xml
+++ b/tei/fane-love-in-the-dark.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fane-the-sacrifice.xml
+++ b/tei/fane-the-sacrifice.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/farquhar-love-and-a-bottle.xml
+++ b/tei/farquhar-love-and-a-bottle.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/farquhar-the-constant-couple.xml
+++ b/tei/farquhar-the-constant-couple.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/field-a-woman-is-a-weathercock.xml
+++ b/tei/field-a-woman-is-a-weathercock.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/field-amends-for-ladies.xml
+++ b/tei/field-amends-for-ladies.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/field-fletcher-massinger-the-knight-of-malta.xml
+++ b/tei/field-fletcher-massinger-the-knight-of-malta.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/field-fletcher-massinger-the-queen-of-corinth.xml
+++ b/tei/field-fletcher-massinger-the-queen-of-corinth.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/field-massinger-fletcher-the-honest-man-s-fortune.xml
+++ b/tei/field-massinger-fletcher-the-honest-man-s-fortune.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/field-massinger-the-fatal-dowry.xml
+++ b/tei/field-massinger-the-fatal-dowry.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fisher-fuimus-troes.xml
+++ b/tei/fisher-fuimus-troes.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/flecknoe-erminia.xml
+++ b/tei/flecknoe-erminia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/flecknoe-love-s-kingdom.xml
+++ b/tei/flecknoe-love-s-kingdom.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/flecknoe-the-damoiselles-a-la-mode.xml
+++ b/tei/flecknoe-the-damoiselles-a-la-mode.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-a-wife-for-a-month.xml
+++ b/tei/fletcher-a-wife-for-a-month.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-beaumont-the-captain.xml
+++ b/tei/fletcher-beaumont-the-captain.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-beaumont-the-noble-gentleman.xml
+++ b/tei/fletcher-beaumont-the-noble-gentleman.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-bonduca.xml
+++ b/tei/fletcher-bonduca.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-field-four-plays.xml
+++ b/tei/fletcher-field-four-plays.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-ford-massinger-webster-the-fair-maid-of-the-inn.xml
+++ b/tei/fletcher-ford-massinger-webster-the-fair-maid-of-the-inn.xml
@@ -36,10 +36,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-a-very-woman.xml
+++ b/tei/fletcher-massinger-a-very-woman.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-bloody-brother-rollo-duke-of-normandy.xml
+++ b/tei/fletcher-massinger-the-bloody-brother-rollo-duke-of-normandy.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-custom-of-the-country.xml
+++ b/tei/fletcher-massinger-the-custom-of-the-country.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-double-marriage.xml
+++ b/tei/fletcher-massinger-the-double-marriage.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-elder-brother.xml
+++ b/tei/fletcher-massinger-the-elder-brother.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-false-one.xml
+++ b/tei/fletcher-massinger-the-false-one.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-little-french-lawyer.xml
+++ b/tei/fletcher-massinger-the-little-french-lawyer.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-prophetess.xml
+++ b/tei/fletcher-massinger-the-prophetess.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-sea-voyage.xml
+++ b/tei/fletcher-massinger-the-sea-voyage.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-spanish-curate.xml
+++ b/tei/fletcher-massinger-the-spanish-curate.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-massinger-the-wandering-lovers.xml
+++ b/tei/fletcher-massinger-the-wandering-lovers.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-rowley-the-maid-in-the-mill.xml
+++ b/tei/fletcher-rowley-the-maid-in-the-mill.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-rule-a-wife-and-have-a-wife.xml
+++ b/tei/fletcher-rule-a-wife-and-have-a-wife.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-shirley-the-night-walker.xml
+++ b/tei/fletcher-shirley-the-night-walker.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-sicelides.xml
+++ b/tei/fletcher-sicelides.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-the-chances.xml
+++ b/tei/fletcher-the-chances.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-the-faithful-shepherdess.xml
+++ b/tei/fletcher-the-faithful-shepherdess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-the-humorous-lieutenant.xml
+++ b/tei/fletcher-the-humorous-lieutenant.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-the-island-princess.xml
+++ b/tei/fletcher-the-island-princess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-the-loyal-subject.xml
+++ b/tei/fletcher-the-loyal-subject.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-the-mad-lover.xml
+++ b/tei/fletcher-the-mad-lover.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-the-pilgrim.xml
+++ b/tei/fletcher-the-pilgrim.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-the-wild-goose-chase.xml
+++ b/tei/fletcher-the-wild-goose-chase.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-the-woman-s-prize.xml
+++ b/tei/fletcher-the-woman-s-prize.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-valentinian.xml
+++ b/tei/fletcher-valentinian.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-wit-without-money.xml
+++ b/tei/fletcher-wit-without-money.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fletcher-women-pleased.xml
+++ b/tei/fletcher-women-pleased.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ford-love-s-sacrifice.xml
+++ b/tei/ford-love-s-sacrifice.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ford-perkin-warbeck.xml
+++ b/tei/ford-perkin-warbeck.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ford-the-broken-heart.xml
+++ b/tei/ford-the-broken-heart.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ford-the-fancies-chaste-and-noble.xml
+++ b/tei/ford-the-fancies-chaste-and-noble.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ford-the-lady-s-trial.xml
+++ b/tei/ford-the-lady-s-trial.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ford-the-laws-of-candy.xml
+++ b/tei/ford-the-laws-of-candy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ford-the-lover-s-melancholy.xml
+++ b/tei/ford-the-lover-s-melancholy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ford-the-queen.xml
+++ b/tei/ford-the-queen.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ford-tis-pity-she-s-a-whore.xml
+++ b/tei/ford-tis-pity-she-s-a-whore.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/freeman-imperiale.xml
+++ b/tei/freeman-imperiale.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/fulwel-like-will-to-like.xml
+++ b/tei/fulwel-like-will-to-like.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/garnier-antonius.xml
+++ b/tei/garnier-antonius.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/garnier-cornelia.xml
+++ b/tei/garnier-cornelia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/garter-the-most-virtuous-and-godly-susanna.xml
+++ b/tei/garter-the-most-virtuous-and-godly-susanna.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/gascoigne-the-glass-of-government.xml
+++ b/tei/gascoigne-the-glass-of-government.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/gildon-measure-for-measure.xml
+++ b/tei/gildon-measure-for-measure.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/glapthorne-albertus-wallenstein.xml
+++ b/tei/glapthorne-albertus-wallenstein.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/glapthorne-argalus-and-parthenia.xml
+++ b/tei/glapthorne-argalus-and-parthenia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/glapthorne-revenge-for-honor.xml
+++ b/tei/glapthorne-revenge-for-honor.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/glapthorne-the-hollander.xml
+++ b/tei/glapthorne-the-hollander.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/glapthorne-the-ladies-privilege.xml
+++ b/tei/glapthorne-the-ladies-privilege.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/glapthorne-wit-in-a-constable.xml
+++ b/tei/glapthorne-wit-in-a-constable.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/goffe-orestes.xml
+++ b/tei/goffe-orestes.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/goffe-the-careless-shepherdess.xml
+++ b/tei/goffe-the-careless-shepherdess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/gomersall-lodovick-sforza.xml
+++ b/tei/gomersall-lodovick-sforza.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/gough-the-strange-discovery.xml
+++ b/tei/gough-the-strange-discovery.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/gould-the-rival-sisters.xml
+++ b/tei/gould-the-rival-sisters.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/granville-heroic-love.xml
+++ b/tei/granville-heroic-love.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/granville-the-she-gallants.xml
+++ b/tei/granville-the-she-gallants.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/greene-alphonsus-king-of-aragon.xml
+++ b/tei/greene-alphonsus-king-of-aragon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/greene-friar-bacon-and-friar-bongay.xml
+++ b/tei/greene-friar-bacon-and-friar-bongay.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/greene-george-a-green-the-pinner-of-wakefield.xml
+++ b/tei/greene-george-a-green-the-pinner-of-wakefield.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/greene-orlando-furioso.xml
+++ b/tei/greene-orlando-furioso.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/greene-selimus-1.xml
+++ b/tei/greene-selimus-1.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/greene-the-scottish-history-of-james-the-fourth.xml
+++ b/tei/greene-the-scottish-history-of-james-the-fourth.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/greville-alaham.xml
+++ b/tei/greville-alaham.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/greville-mustapha.xml
+++ b/tei/greville-mustapha.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/grotius-christ-s-passion.xml
+++ b/tei/grotius-christ-s-passion.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/guarini-il-pastor-fido-1602.xml
+++ b/tei/guarini-il-pastor-fido-1602.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/guarini-il-pastor-fido-1647.xml
+++ b/tei/guarini-il-pastor-fido-1647.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/habington-the-queen-of-aragon.xml
+++ b/tei/habington-the-queen-of-aragon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/harding-sicily-and-naples.xml
+++ b/tei/harding-sicily-and-naples.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/harris-the-city-bride.xml
+++ b/tei/harris-the-city-bride.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/harris-the-mistakes.xml
+++ b/tei/harris-the-mistakes.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/haughton-englishmen-for-my-money.xml
+++ b/tei/haughton-englishmen-for-my-money.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/hausted-the-rival-friends.xml
+++ b/tei/hausted-the-rival-friends.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/hawkins-apollo-shroving.xml
+++ b/tei/hawkins-apollo-shroving.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/haynes-a-fatal-mistake.xml
+++ b/tei/haynes-a-fatal-mistake.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-a-challenge-for-beauty.xml
+++ b/tei/heywood-a-challenge-for-beauty.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-a-maidenhead-well-lost.xml
+++ b/tei/heywood-a-maidenhead-well-lost.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-a-woman-killed-with-kindness.xml
+++ b/tei/heywood-a-woman-killed-with-kindness.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-brome-the-late-lancashire-witches.xml
+++ b/tei/heywood-brome-the-late-lancashire-witches.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-edward-the-fourth-1.xml
+++ b/tei/heywood-edward-the-fourth-1.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-how-a-man-may-choose-a-good-wife-from-a-bad.xml
+++ b/tei/heywood-how-a-man-may-choose-a-good-wife-from-a-bad.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-if-you-know-not-me-you-know-nobody-1.xml
+++ b/tei/heywood-if-you-know-not-me-you-know-nobody-1.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-if-you-know-not-me-you-know-nobody-2.xml
+++ b/tei/heywood-if-you-know-not-me-you-know-nobody-2.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-love-s-mistress.xml
+++ b/tei/heywood-love-s-mistress.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-rowley-fortune-by-land-and-sea.xml
+++ b/tei/heywood-rowley-fortune-by-land-and-sea.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-brazen-age.xml
+++ b/tei/heywood-the-brazen-age.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-english-traveller.xml
+++ b/tei/heywood-the-english-traveller.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-fair-maid-of-the-exchange.xml
+++ b/tei/heywood-the-fair-maid-of-the-exchange.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-fair-maid-of-the-west-1.xml
+++ b/tei/heywood-the-fair-maid-of-the-west-1.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-fair-maid-of-the-west-2.xml
+++ b/tei/heywood-the-fair-maid-of-the-west-2.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-four-prentices-of-london.xml
+++ b/tei/heywood-the-four-prentices-of-london.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-golden-age.xml
+++ b/tei/heywood-the-golden-age.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-iron-age-1.xml
+++ b/tei/heywood-the-iron-age-1.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-iron-age-2.xml
+++ b/tei/heywood-the-iron-age-2.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-rape-of-lucrece.xml
+++ b/tei/heywood-the-rape-of-lucrece.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-royal-king-and-the-loyal-subject.xml
+++ b/tei/heywood-the-royal-king-and-the-loyal-subject.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/heywood-the-wise-woman-of-hogsdon.xml
+++ b/tei/heywood-the-wise-woman-of-hogsdon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/higden-the-wary-widow.xml
+++ b/tei/higden-the-wary-widow.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/holiday-technogamia.xml
+++ b/tei/holiday-technogamia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/howard-all-mistaken.xml
+++ b/tei/howard-all-mistaken.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/howard-the-english-monsieur.xml
+++ b/tei/howard-the-english-monsieur.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/howard-the-man-of-newmarket.xml
+++ b/tei/howard-the-man-of-newmarket.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/howard-the-six-days-adventure.xml
+++ b/tei/howard-the-six-days-adventure.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/howard-the-usurper.xml
+++ b/tei/howard-the-usurper.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/howard-the-women-s-conquest.xml
+++ b/tei/howard-the-women-s-conquest.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/hughes-the-misfortunes-of-arthur.xml
+++ b/tei/hughes-the-misfortunes-of-arthur.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/hurtado-de-mendoza-to-love-only-for-love-s-sake.xml
+++ b/tei/hurtado-de-mendoza-to-love-only-for-love-s-sake.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jevon-the-devil-of-a-wife.xml
+++ b/tei/jevon-the-devil-of-a-wife.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jones-adrasta.xml
+++ b/tei/jones-adrasta.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-bartholomew-fair.xml
+++ b/tei/jonson-bartholomew-fair.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-catiline-his-conspiracy.xml
+++ b/tei/jonson-catiline-his-conspiracy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-chloridia.xml
+++ b/tei/jonson-chloridia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-cynthia-s-revels.xml
+++ b/tei/jonson-cynthia-s-revels.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-epicoene-or-the-silent-woman-A04632_07.xml
+++ b/tei/jonson-epicoene-or-the-silent-woman-A04632_07.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-epicoene-or-the-silent-woman-A04645.xml
+++ b/tei/jonson-epicoene-or-the-silent-woman-A04645.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-every-man-in-his-humour.xml
+++ b/tei/jonson-every-man-in-his-humour.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-every-man-out-of-his-humor.xml
+++ b/tei/jonson-every-man-out-of-his-humor.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-every-man-out-of-his-humour.xml
+++ b/tei/jonson-every-man-out-of-his-humour.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-hymenaei.xml
+++ b/tei/jonson-hymenaei.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-love-s-triumph-through-callipolis.xml
+++ b/tei/jonson-love-s-triumph-through-callipolis.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-neptune-s-triumph-for-the-return-of-albion.xml
+++ b/tei/jonson-neptune-s-triumph-for-the-return-of-albion.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-poetaster.xml
+++ b/tei/jonson-poetaster.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-sejanus-his-fall.xml
+++ b/tei/jonson-sejanus-his-fall.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-the-alchemist.xml
+++ b/tei/jonson-the-alchemist.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-the-case-is-altered.xml
+++ b/tei/jonson-the-case-is-altered.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-the-characters-of-two-royal-masques.xml
+++ b/tei/jonson-the-characters-of-two-royal-masques.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-the-devil-is-an-ass.xml
+++ b/tei/jonson-the-devil-is-an-ass.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-the-entertainment-of-the-queen-and-prince-at-althorp.xml
+++ b/tei/jonson-the-entertainment-of-the-queen-and-prince-at-althorp.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-the-fortunate-isles-and-their-union.xml
+++ b/tei/jonson-the-fortunate-isles-and-their-union.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-the-new-inn.xml
+++ b/tei/jonson-the-new-inn.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-the-staple-of-news.xml
+++ b/tei/jonson-the-staple-of-news.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/jonson-volpone.xml
+++ b/tei/jonson-volpone.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/killigrew-claricilla.xml
+++ b/tei/killigrew-claricilla.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/killigrew-the-conspiracy.xml
+++ b/tei/killigrew-the-conspiracy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/killigrew-the-imperial-tragedy.xml
+++ b/tei/killigrew-the-imperial-tragedy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/killigrew-the-parson-s-wedding.xml
+++ b/tei/killigrew-the-parson-s-wedding.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/killigrew-the-princess.xml
+++ b/tei/killigrew-the-princess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/killigrew-the-prisoners.xml
+++ b/tei/killigrew-the-prisoners.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/kirke-the-seven-champions-of-christendom.xml
+++ b/tei/kirke-the-seven-champions-of-christendom.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/knevet-rhodon-and-iris.xml
+++ b/tei/knevet-rhodon-and-iris.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/kyd-soliman-and-perseda.xml
+++ b/tei/kyd-soliman-and-perseda.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/kyd-the-spanish-tragedy.xml
+++ b/tei/kyd-the-spanish-tragedy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/kynaston-corona-minervae.xml
+++ b/tei/kynaston-corona-minervae.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lacy-sauny-the-scot.xml
+++ b/tei/lacy-sauny-the-scot.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lacy-sir-hercules-buffoon.xml
+++ b/tei/lacy-sir-hercules-buffoon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lacy-the-dumb-lady.xml
+++ b/tei/lacy-the-dumb-lady.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lacy-the-old-troop.xml
+++ b/tei/lacy-the-old-troop.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/leanerd-the-rambling-justice.xml
+++ b/tei/leanerd-the-rambling-justice.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-caesar-borgia-son-of-pope-alexander-vi.xml
+++ b/tei/lee-caesar-borgia-son-of-pope-alexander-vi.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-constantine-the-great.xml
+++ b/tei/lee-constantine-the-great.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-gloriana.xml
+++ b/tei/lee-gloriana.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-lucius-junius-brutus-father-of-his-country.xml
+++ b/tei/lee-lucius-junius-brutus-father-of-his-country.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-mithridates-king-of-pontus.xml
+++ b/tei/lee-mithridates-king-of-pontus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-nero-emperor-of-rome.xml
+++ b/tei/lee-nero-emperor-of-rome.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-sophonisba.xml
+++ b/tei/lee-sophonisba.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-the-massacre-of-paris.xml
+++ b/tei/lee-the-massacre-of-paris.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-the-princess-of-cleve.xml
+++ b/tei/lee-the-princess-of-cleve.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-the-rival-queens.xml
+++ b/tei/lee-the-rival-queens.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lee-theodosius.xml
+++ b/tei/lee-theodosius.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lodge-the-wounds-of-civil-war.xml
+++ b/tei/lodge-the-wounds-of-civil-war.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lower-the-phoenix-in-her-flames.xml
+++ b/tei/lower-the-phoenix-in-her-flames.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lupton-all-for-money.xml
+++ b/tei/lupton-all-for-money.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lyly-campaspe.xml
+++ b/tei/lyly-campaspe.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lyly-endymion.xml
+++ b/tei/lyly-endymion.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lyly-gallathea.xml
+++ b/tei/lyly-gallathea.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lyly-love-s-metamorphosis.xml
+++ b/tei/lyly-love-s-metamorphosis.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lyly-midas.xml
+++ b/tei/lyly-midas.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lyly-mother-bombie.xml
+++ b/tei/lyly-mother-bombie.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lyly-sappho-and-phao.xml
+++ b/tei/lyly-sappho-and-phao.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/lyly-the-woman-in-the-moon.xml
+++ b/tei/lyly-the-woman-in-the-moon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/machin-barkstead-marston-the-insatiate-countess.xml
+++ b/tei/machin-barkstead-marston-the-insatiate-countess.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/maidwell-the-loving-enemies.xml
+++ b/tei/maidwell-the-loving-enemies.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/markham-sampson-herod-and-antipater.xml
+++ b/tei/markham-sampson-herod-and-antipater.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marlowe-dr-faustus.xml
+++ b/tei/marlowe-dr-faustus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marlowe-edward-the-second.xml
+++ b/tei/marlowe-edward-the-second.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marlowe-nashe-dido-queen-of-carthage.xml
+++ b/tei/marlowe-nashe-dido-queen-of-carthage.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marlowe-tamburlaine-1.xml
+++ b/tei/marlowe-tamburlaine-1.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marlowe-the-jew-of-malta.xml
+++ b/tei/marlowe-the-jew-of-malta.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marlowe-the-massacre-at-paris.xml
+++ b/tei/marlowe-the-massacre-at-paris.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marmion-a-fine-companion.xml
+++ b/tei/marmion-a-fine-companion.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marmion-holland-s-leaguer.xml
+++ b/tei/marmion-holland-s-leaguer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marston-antonio-and-mellida.xml
+++ b/tei/marston-antonio-and-mellida.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marston-antonio-s-revenge.xml
+++ b/tei/marston-antonio-s-revenge.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marston-histriomastix.xml
+++ b/tei/marston-histriomastix.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marston-jack-drum-s-entertainment.xml
+++ b/tei/marston-jack-drum-s-entertainment.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marston-parasitaster.xml
+++ b/tei/marston-parasitaster.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marston-the-dutch-courtesan.xml
+++ b/tei/marston-the-dutch-courtesan.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marston-the-malcontent.xml
+++ b/tei/marston-the-malcontent.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marston-the-wonder-of-women.xml
+++ b/tei/marston-the-wonder-of-women.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/marston-what-you-will.xml
+++ b/tei/marston-what-you-will.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/mason-the-turk.xml
+++ b/tei/mason-the-turk.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-a-new-way-to-pay-old-debts.xml
+++ b/tei/massinger-a-new-way-to-pay-old-debts.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-bashful-lover.xml
+++ b/tei/massinger-the-bashful-lover.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-bondman.xml
+++ b/tei/massinger-the-bondman.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-city-madam.xml
+++ b/tei/massinger-the-city-madam.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-duke-of-milan.xml
+++ b/tei/massinger-the-duke-of-milan.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-emperor-of-the-east.xml
+++ b/tei/massinger-the-emperor-of-the-east.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-great-duke-of-florence.xml
+++ b/tei/massinger-the-great-duke-of-florence.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-guardian.xml
+++ b/tei/massinger-the-guardian.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-maid-of-honour.xml
+++ b/tei/massinger-the-maid-of-honour.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-picture.xml
+++ b/tei/massinger-the-picture.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-renegado.xml
+++ b/tei/massinger-the-renegado.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-roman-actor.xml
+++ b/tei/massinger-the-roman-actor.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/massinger-the-unnatural-combat.xml
+++ b/tei/massinger-the-unnatural-combat.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/may-antigone-the-theban-princess.xml
+++ b/tei/may-antigone-the-theban-princess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/may-cleopatra-queen-of-egypt.xml
+++ b/tei/may-cleopatra-queen-of-egypt.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/may-julia-agrippina-empress-of-rome.xml
+++ b/tei/may-julia-agrippina-empress-of-rome.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/may-the-heir.xml
+++ b/tei/may-the-heir.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/mayne-the-city-match.xml
+++ b/tei/mayne-the-city-match.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-a-chaste-maid-in-cheapside.xml
+++ b/tei/middleton-a-chaste-maid-in-cheapside.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-a-game-at-chess.xml
+++ b/tei/middleton-a-game-at-chess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-a-mad-world-my-masters.xml
+++ b/tei/middleton-a-mad-world-my-masters.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-a-trick-to-catch-the-old-one.xml
+++ b/tei/middleton-a-trick-to-catch-the-old-one.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-a-yorkshire-tragedy.xml
+++ b/tei/middleton-a-yorkshire-tragedy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-anything-for-a-quiet-life.xml
+++ b/tei/middleton-anything-for-a-quiet-life.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-fletcher-the-nice-valor.xml
+++ b/tei/middleton-fletcher-the-nice-valor.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-michaelmas-term.xml
+++ b/tei/middleton-michaelmas-term.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-more-dissemblers-besides-women.xml
+++ b/tei/middleton-more-dissemblers-besides-women.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-rowley-heywood-the-old-law.xml
+++ b/tei/middleton-rowley-heywood-the-old-law.xml
@@ -29,10 +29,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-rowley-the-changeling.xml
+++ b/tei/middleton-rowley-the-changeling.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-rowley-the-world-tossed-at-tennis.xml
+++ b/tei/middleton-rowley-the-world-tossed-at-tennis.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-rowley-wit-at-several-weapons.xml
+++ b/tei/middleton-rowley-wit-at-several-weapons.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-the-family-of-love.xml
+++ b/tei/middleton-the-family-of-love.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-the-inner-temple-masque.xml
+++ b/tei/middleton-the-inner-temple-masque.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-the-mayor-of-quinborough.xml
+++ b/tei/middleton-the-mayor-of-quinborough.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-the-phoenix.xml
+++ b/tei/middleton-the-phoenix.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-the-puritan.xml
+++ b/tei/middleton-the-puritan.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-the-revenger-s-tragedy.xml
+++ b/tei/middleton-the-revenger-s-tragedy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-the-widow.xml
+++ b/tei/middleton-the-widow.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-william-rowley-a-fair-quarrel.xml
+++ b/tei/middleton-william-rowley-a-fair-quarrel.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-women-beware-women.xml
+++ b/tei/middleton-women-beware-women.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/middleton-your-five-gallants.xml
+++ b/tei/middleton-your-five-gallants.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/milton-comus.xml
+++ b/tei/milton-comus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/motteux-beauty-in-distress.xml
+++ b/tei/motteux-beauty-in-distress.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/motteux-love-s-a-jest.xml
+++ b/tei/motteux-love-s-a-jest.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/motteux-the-island-princess.xml
+++ b/tei/motteux-the-island-princess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/mountfort-doctor-faustus.xml
+++ b/tei/mountfort-doctor-faustus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/mountfort-edward-iii-with-the-fall-of-mortimer.xml
+++ b/tei/mountfort-edward-iii-with-the-fall-of-mortimer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/mountfort-greenwich-park.xml
+++ b/tei/mountfort-greenwich-park.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/mountfort-the-injured-lovers.xml
+++ b/tei/mountfort-the-injured-lovers.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/munday-chettle-the-death-of-robert-earl-of-huntingdon.xml
+++ b/tei/munday-chettle-the-death-of-robert-earl-of-huntingdon.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/munday-drayton-wilson-hathaway-sir-john-oldcastle-1.xml
+++ b/tei/munday-drayton-wilson-hathaway-sir-john-oldcastle-1.xml
@@ -36,10 +36,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/nabbes-covent-garden.xml
+++ b/tei/nabbes-covent-garden.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/nabbes-hannibal-and-scipio.xml
+++ b/tei/nabbes-hannibal-and-scipio.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/nabbes-the-bride.xml
+++ b/tei/nabbes-the-bride.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/nabbes-the-spring-s-glory.xml
+++ b/tei/nabbes-the-spring-s-glory.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/nabbes-the-unfortunate-mother.xml
+++ b/tei/nabbes-the-unfortunate-mother.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/nabbes-tottenham-court.xml
+++ b/tei/nabbes-tottenham-court.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/nashe-summer-s-last-will-and-testament.xml
+++ b/tei/nashe-summer-s-last-will-and-testament.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/norton-pausanious-the-betrayer-of-his-country.xml
+++ b/tei/norton-pausanious-the-betrayer-of-his-country.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/norton-sackville-gorboduc.xml
+++ b/tei/norton-sackville-gorboduc.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/otway-alcibiades.xml
+++ b/tei/otway-alcibiades.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/otway-caius-marius.xml
+++ b/tei/otway-caius-marius.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/otway-don-carlos-prince-of-spain.xml
+++ b/tei/otway-don-carlos-prince-of-spain.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/otway-the-atheist.xml
+++ b/tei/otway-the-atheist.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/otway-the-orphan.xml
+++ b/tei/otway-the-orphan.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/otway-the-soldier-s-fortune.xml
+++ b/tei/otway-the-soldier-s-fortune.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/otway-titus-and-berenice.xml
+++ b/tei/otway-titus-and-berenice.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pasqualigo-fedele-and-fortunia.xml
+++ b/tei/pasqualigo-fedele-and-fortunia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/peele-clyomon-and-clamydes.xml
+++ b/tei/peele-clyomon-and-clamydes.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/peele-edward-the-first.xml
+++ b/tei/peele-edward-the-first.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/peele-the-arraignment-of-paris.xml
+++ b/tei/peele-the-arraignment-of-paris.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/peele-the-battle-of-alcazar.xml
+++ b/tei/peele-the-battle-of-alcazar.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/peele-the-love-of-david-and-fair-bathsheba.xml
+++ b/tei/peele-the-love-of-david-and-fair-bathsheba.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/peele-the-old-wives-tale.xml
+++ b/tei/peele-the-old-wives-tale.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/perrin-ariadne.xml
+++ b/tei/perrin-ariadne.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/phillips-st-stephen-s-green.xml
+++ b/tei/phillips-st-stephen-s-green.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/phillips-the-revengeful-queen.xml
+++ b/tei/phillips-the-revengeful-queen.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pikering-horestes.xml
+++ b/tei/pikering-horestes.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pix-ibrahim-the-thirteenth-emperor-of-the-turks.xml
+++ b/tei/pix-ibrahim-the-thirteenth-emperor-of-the-turks.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pix-the-beau-defeated.xml
+++ b/tei/pix-the-beau-defeated.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pix-the-deceiver-deceived.xml
+++ b/tei/pix-the-deceiver-deceived.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pix-the-false-friend.xml
+++ b/tei/pix-the-false-friend.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pix-the-innocent-mistress.xml
+++ b/tei/pix-the-innocent-mistress.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pix-the-spanish-wives.xml
+++ b/tei/pix-the-spanish-wives.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pordage-herod-and-mariamne.xml
+++ b/tei/pordage-herod-and-mariamne.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/pordage-the-siege-of-babylon.xml
+++ b/tei/pordage-the-siege-of-babylon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/porter-a-witty-combat.xml
+++ b/tei/porter-a-witty-combat.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/porter-the-carnival.xml
+++ b/tei/porter-the-carnival.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/porter-the-french-conjurer.xml
+++ b/tei/porter-the-french-conjurer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/porter-the-two-angry-women-of-abingdon.xml
+++ b/tei/porter-the-two-angry-women-of-abingdon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/porter-the-villain.xml
+++ b/tei/porter-the-villain.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/powell-a-very-good-wife.xml
+++ b/tei/powell-a-very-good-wife.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/powell-alphonso-king-of-naples.xml
+++ b/tei/powell-alphonso-king-of-naples.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/powell-the-imposture-defeated.xml
+++ b/tei/powell-the-imposture-defeated.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/powell-the-treacherous-brothers.xml
+++ b/tei/powell-the-treacherous-brothers.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/randolph-aristippus-or-the-jovial-philosopher.xml
+++ b/tei/randolph-aristippus-or-the-jovial-philosopher.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/randolph-the-jealous-lovers.xml
+++ b/tei/randolph-the-jealous-lovers.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-dame-dobson.xml
+++ b/tei/ravenscroft-dame-dobson.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-king-edgar-and-alfreda.xml
+++ b/tei/ravenscroft-king-edgar-and-alfreda.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-scaramouch-a-philosopher.xml
+++ b/tei/ravenscroft-scaramouch-a-philosopher.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-the-anatomist.xml
+++ b/tei/ravenscroft-the-anatomist.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-the-canterbury-guests.xml
+++ b/tei/ravenscroft-the-canterbury-guests.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-the-careless-lovers.xml
+++ b/tei/ravenscroft-the-careless-lovers.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-the-citizen-turned-gentleman.xml
+++ b/tei/ravenscroft-the-citizen-turned-gentleman.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-the-english-lawyer.xml
+++ b/tei/ravenscroft-the-english-lawyer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-the-italian-husband.xml
+++ b/tei/ravenscroft-the-italian-husband.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-the-wrangling-lovers.xml
+++ b/tei/ravenscroft-the-wrangling-lovers.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ravenscroft-titus-andronicus.xml
+++ b/tei/ravenscroft-titus-andronicus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rawlins-the-rebellion.xml
+++ b/tei/rawlins-the-rebellion.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rawlins-tom-essence.xml
+++ b/tei/rawlins-tom-essence.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rawlins-tunbridge-wells.xml
+++ b/tei/rawlins-tunbridge-wells.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/richards-messalina-the-roman-empress.xml
+++ b/tei/richards-messalina-the-roman-empress.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rojas-the-spanish-bawd.xml
+++ b/tei/rojas-the-spanish-bawd.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rowley-a-match-at-midnight.xml
+++ b/tei/rowley-a-match-at-midnight.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rowley-a-new-wonder-a-woman-never-vexed.xml
+++ b/tei/rowley-a-new-wonder-a-woman-never-vexed.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rowley-a-shoemaker-a-gentleman.xml
+++ b/tei/rowley-a-shoemaker-a-gentleman.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rowley-all-s-lost-by-lust.xml
+++ b/tei/rowley-all-s-lost-by-lust.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rowley-the-birth-of-merlin.xml
+++ b/tei/rowley-the-birth-of-merlin.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rowley-when-you-see-me-you-know-me.xml
+++ b/tei/rowley-when-you-see-me-you-know-me.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/ruggle-ignoramus.xml
+++ b/tei/ruggle-ignoramus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/rutter-the-shepherds-holiday.xml
+++ b/tei/rutter-the-shepherds-holiday.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/s-the-honest-lawyer.xml
+++ b/tei/s-the-honest-lawyer.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/s-thomas-lord-cromwell.xml
+++ b/tei/s-thomas-lord-cromwell.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/sampson-the-vow-breaker.xml
+++ b/tei/sampson-the-vow-breaker.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/saunders-tamerlane-the-great.xml
+++ b/tei/saunders-tamerlane-the-great.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/sedley-antony-and-cleopatra.xml
+++ b/tei/sedley-antony-and-cleopatra.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/sedley-bellamira.xml
+++ b/tei/sedley-bellamira.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/sedley-the-mulberry-garden.xml
+++ b/tei/sedley-the-mulberry-garden.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-agamemnon.xml
+++ b/tei/seneca-agamemnon.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-hercules-furens.xml
+++ b/tei/seneca-hercules-furens.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-hercules-oetaeus.xml
+++ b/tei/seneca-hercules-oetaeus.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-hippolytus.xml
+++ b/tei/seneca-hippolytus.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-medea.xml
+++ b/tei/seneca-medea.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-octavia.xml
+++ b/tei/seneca-octavia.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-oedipus.xml
+++ b/tei/seneca-oedipus.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-thebais.xml
+++ b/tei/seneca-thebais.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-thyestes.xml
+++ b/tei/seneca-thyestes.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-troades.xml
+++ b/tei/seneca-troades.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/seneca-troas.xml
+++ b/tei/seneca-troas.xml
@@ -18,10 +18,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-cambyses-king-of-persia.xml
+++ b/tei/settle-cambyses-king-of-persia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-fatal-love.xml
+++ b/tei/settle-fatal-love.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-ibrahim-the-illustrious-bassa.xml
+++ b/tei/settle-ibrahim-the-illustrious-bassa.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-love-and-revenge.xml
+++ b/tei/settle-love-and-revenge.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-pastor-fido.xml
+++ b/tei/settle-pastor-fido.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-the-ambitious-slave.xml
+++ b/tei/settle-the-ambitious-slave.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-the-conquest-of-china-by-the-tartars.xml
+++ b/tei/settle-the-conquest-of-china-by-the-tartars.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-the-empress-of-morocco.xml
+++ b/tei/settle-the-empress-of-morocco.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-the-female-prelate.xml
+++ b/tei/settle-the-female-prelate.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-the-heir-of-morocco.xml
+++ b/tei/settle-the-heir-of-morocco.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/settle-the-world-in-the-moon.xml
+++ b/tei/settle-the-world-in-the-moon.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-a-true-widow.xml
+++ b/tei/shadwell-a-true-widow.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-bury-fair.xml
+++ b/tei/shadwell-bury-fair.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-epsom-wells.xml
+++ b/tei/shadwell-epsom-wells.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-psyche.xml
+++ b/tei/shadwell-psyche.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-humorists.xml
+++ b/tei/shadwell-the-humorists.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-lancashire-witches-and-tegue-o-divelly.xml
+++ b/tei/shadwell-the-lancashire-witches-and-tegue-o-divelly.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-libertine.xml
+++ b/tei/shadwell-the-libertine.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-miser.xml
+++ b/tei/shadwell-the-miser.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-royal-shepherdess.xml
+++ b/tei/shadwell-the-royal-shepherdess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-scowrers.xml
+++ b/tei/shadwell-the-scowrers.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-squire-of-alsatia.xml
+++ b/tei/shadwell-the-squire-of-alsatia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-sullen-lovers.xml
+++ b/tei/shadwell-the-sullen-lovers.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-virtuoso.xml
+++ b/tei/shadwell-the-virtuoso.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shadwell-the-woman-captain.xml
+++ b/tei/shadwell-the-woman-captain.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/sharpham-cupid-s-whirligig.xml
+++ b/tei/sharpham-cupid-s-whirligig.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/sharpham-the-fleer.xml
+++ b/tei/sharpham-the-fleer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shipman-henry-iii-of-france.xml
+++ b/tei/shipman-henry-iii-of-france.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-changes.xml
+++ b/tei/shirley-changes.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-hyde-park.xml
+++ b/tei/shirley-hyde-park.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-love-s-cruelty.xml
+++ b/tei/shirley-love-s-cruelty.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-saint-patrick-for-ireland-1.xml
+++ b/tei/shirley-saint-patrick-for-ireland-1.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-arcadia.xml
+++ b/tei/shirley-the-arcadia.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-ball.xml
+++ b/tei/shirley-the-ball.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-bird-in-a-cage.xml
+++ b/tei/shirley-the-bird-in-a-cage.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-brothers.xml
+++ b/tei/shirley-the-brothers.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-cardinal.xml
+++ b/tei/shirley-the-cardinal.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-constant-maid.xml
+++ b/tei/shirley-the-constant-maid.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-contention-for-honor-and-riches.xml
+++ b/tei/shirley-the-contention-for-honor-and-riches.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-court-secret.xml
+++ b/tei/shirley-the-court-secret.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-doubtful-heir.xml
+++ b/tei/shirley-the-doubtful-heir.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-duke-s-mistress.xml
+++ b/tei/shirley-the-duke-s-mistress.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-example.xml
+++ b/tei/shirley-the-example.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-gamester.xml
+++ b/tei/shirley-the-gamester.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-gentleman-of-venice.xml
+++ b/tei/shirley-the-gentleman-of-venice.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-humorous-courtier.xml
+++ b/tei/shirley-the-humorous-courtier.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-impostor.xml
+++ b/tei/shirley-the-impostor.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-lady-of-pleasure.xml
+++ b/tei/shirley-the-lady-of-pleasure.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-maid-s-revenge.xml
+++ b/tei/shirley-the-maid-s-revenge.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-martyred-soldier.xml
+++ b/tei/shirley-the-martyred-soldier.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-opportunity.xml
+++ b/tei/shirley-the-opportunity.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-politician.xml
+++ b/tei/shirley-the-politician.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-royal-master.xml
+++ b/tei/shirley-the-royal-master.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-school-of-compliment.xml
+++ b/tei/shirley-the-school-of-compliment.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-sisters.xml
+++ b/tei/shirley-the-sisters.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-traitor.xml
+++ b/tei/shirley-the-traitor.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-triumph-of-peace.xml
+++ b/tei/shirley-the-triumph-of-peace.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-wedding.xml
+++ b/tei/shirley-the-wedding.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-witty-fair-one.xml
+++ b/tei/shirley-the-witty-fair-one.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/shirley-the-young-admiral.xml
+++ b/tei/shirley-the-young-admiral.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/smith-smith-the-hector-of-germany.xml
+++ b/tei/smith-smith-the-hector-of-germany.xml
@@ -21,10 +21,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/southerne-oroonoko.xml
+++ b/tei/southerne-oroonoko.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/southerne-the-fatal-marriage.xml
+++ b/tei/southerne-the-fatal-marriage.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/southerne-the-loyal-brother.xml
+++ b/tei/southerne-the-loyal-brother.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/southerne-the-maid-s-last-prayer.xml
+++ b/tei/southerne-the-maid-s-last-prayer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/southerne-the-wives-excuse.xml
+++ b/tei/southerne-the-wives-excuse.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/st-serfe-tarugo-s-wiles.xml
+++ b/tei/st-serfe-tarugo-s-wiles.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/stapylton-hero-and-leander.xml
+++ b/tei/stapylton-hero-and-leander.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/stapylton-the-slighted-maid.xml
+++ b/tei/stapylton-the-slighted-maid.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/stapylton-the-stepmother.xml
+++ b/tei/stapylton-the-stepmother.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/stephens-cynthia-s-revenge.xml
+++ b/tei/stephens-cynthia-s-revenge.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/stevenson-gammer-gurton-s-needle.xml
+++ b/tei/stevenson-gammer-gurton-s-needle.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/suckling-aglaura.xml
+++ b/tei/suckling-aglaura.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/suckling-brennoralt.xml
+++ b/tei/suckling-brennoralt.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/tailor-the-hog-hath-lost-his-pearl.xml
+++ b/tei/tailor-the-hog-hath-lost-his-pearl.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/tate-brutus-of-alba.xml
+++ b/tei/tate-brutus-of-alba.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/tate-cuckolds-haven.xml
+++ b/tei/tate-cuckolds-haven.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/tate-the-ingratitude-of-a-commonwealth.xml
+++ b/tei/tate-the-ingratitude-of-a-commonwealth.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/tate-the-island-princess.xml
+++ b/tei/tate-the-island-princess.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/tate-the-loyal-general.xml
+++ b/tei/tate-the-loyal-general.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/terence-andria.xml
+++ b/tei/terence-andria.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/tomkis-albumazar.xml
+++ b/tei/tomkis-albumazar.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/tomkis-lingua.xml
+++ b/tei/tomkis-lingua.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/tourneur-the-atheist-s-tragedy.xml
+++ b/tei/tourneur-the-atheist-s-tragedy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/townshend-albion-s-triumph.xml
+++ b/tei/townshend-albion-s-triumph.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/townshend-tempe-restored.xml
+++ b/tei/townshend-tempe-restored.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/trotter-agnes-de-castro.xml
+++ b/tei/trotter-agnes-de-castro.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/trotter-fatal-friendship.xml
+++ b/tei/trotter-fatal-friendship.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/udall-jacob-and-esau.xml
+++ b/tei/udall-jacob-and-esau.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/udall-ralph-roister-doister.xml
+++ b/tei/udall-ralph-roister-doister.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/vanbrugh-aesop-1-2.xml
+++ b/tei/vanbrugh-aesop-1-2.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/vanbrugh-the-provoked-wife.xml
+++ b/tei/vanbrugh-the-provoked-wife.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/vanbrugh-the-relapse.xml
+++ b/tei/vanbrugh-the-relapse.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/villiers-the-rehearsal.xml
+++ b/tei/villiers-the-rehearsal.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/w-the-valiant-scot.xml
+++ b/tei/w-the-valiant-scot.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/waller-the-maid-s-tragedy.xml
+++ b/tei/waller-the-maid-s-tragedy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wapull-the-tide-tarrieth-no-man.xml
+++ b/tei/wapull-the-tide-tarrieth-no-man.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/webster-rowley-the-thracian-wonder.xml
+++ b/tei/webster-rowley-the-thracian-wonder.xml
@@ -22,10 +22,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/webster-the-devil-s-law-case.xml
+++ b/tei/webster-the-devil-s-law-case.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/webster-the-duchess-of-malfi.xml
+++ b/tei/webster-the-duchess-of-malfi.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/webster-the-white-devil.xml
+++ b/tei/webster-the-white-devil.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/whitaker-the-conspiracy.xml
+++ b/tei/whitaker-the-conspiracy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wilkins-the-miseries-of-enforced-marriage.xml
+++ b/tei/wilkins-the-miseries-of-enforced-marriage.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wilmot-hatton-noel-al-stafford-tancred-and-gismund.xml
+++ b/tei/wilmot-hatton-noel-al-stafford-tancred-and-gismund.xml
@@ -38,10 +38,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wilson-andronicus-comnenus.xml
+++ b/tei/wilson-andronicus-comnenus.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wilson-belphegor.xml
+++ b/tei/wilson-belphegor.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wilson-the-cheats.xml
+++ b/tei/wilson-the-cheats.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wilson-the-cobbler-s-prophecy.xml
+++ b/tei/wilson-the-cobbler-s-prophecy.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wilson-the-projectors.xml
+++ b/tei/wilson-the-projectors.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wilson-the-three-ladies-of-london.xml
+++ b/tei/wilson-the-three-ladies-of-london.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wilson-the-three-lords-and-three-ladies-of-london.xml
+++ b/tei/wilson-the-three-lords-and-three-ladies-of-london.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/woodes-the-conflict-of-conscience.xml
+++ b/tei/woodes-the-conflict-of-conscience.xml
@@ -14,10 +14,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wycherley-love-in-a-wood.xml
+++ b/tei/wycherley-love-in-a-wood.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wycherley-the-country-wife.xml
+++ b/tei/wycherley-the-country-wife.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wycherley-the-gentleman-dancing-master.xml
+++ b/tei/wycherley-the-gentleman-dancing-master.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/wycherley-the-plain-dealer.xml
+++ b/tei/wycherley-the-plain-dealer.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/yarington-two-lamentable-tragedies.xml
+++ b/tei/yarington-two-lamentable-tragedies.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>

--- a/tei/zouche-the-sophister.xml
+++ b/tei/zouche-the-sophister.xml
@@ -15,10 +15,7 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org/</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
-          </licence>
+          <licence target="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC 3.0</licence>
         </availability>
         <idno type="wikidata" xml:base="http://www.wikidata.org/entity/"/>
       </publicationStmt>


### PR DESCRIPTION
This adopts the simplified licence markup from dracor-org/dracor-schema#164 and also changes the licence for each file from CC0 1.0 to CC BY-NC 3.0 which is the one we added for the corpus in 667190637bd1ce0e8701c90e3e5c5a378920d837.